### PR TITLE
11 忍時之忿이면 免百日憂니라

### DIFF
--- a/hanjas.csv
+++ b/hanjas.csv
@@ -54,3 +54,11 @@
 寬 ,14,너그러울 관,너그럽다,넓다,ひろい,1,ser generoso,ser amplio
 從,11,좇을 종,좇다,따르다,したが,3,perseguir,seguir
 萬,12,일 만,일만,,まん,1,infinito,
+事,8,일 사,일,섬기다,ジ,4,trabajo,pendiente
+忍,7,참을 일,참다,,ニン,1,aguantar,
+時,10,때 시,대,계절,ジ,5,tiempo,temporada
+忿,8,성낼 분,분,성내다,フン,3,minuto,perder temperamento
+免,7,"면할 면, 해산할 문",변하다,면하다,メン,1,cambiar,escapar
+百,5,"일백 백, 힘쓸 맥",일백,,ヒャク,5,cien,
+日,4,날 일,일,,ひ,5,día,
+憂,15,근심 우,근심,걱정,ユウ,1,ansiedad,preocupación


### PR DESCRIPTION
해석:
Enduring a once-in-a-lifetime anger saves you a hundred days of anxiety.

If you endure the anger at one time, you can avoid 100 days of anxiety, which means that it is difficult to endure, and if you endure it, it is as beneficial. Through the two kings of the Joseon Dynasty, we can see how much difference the results of patience differ.

King Sejong never got angry and blamed Choi Man-ri, a minor scholar of Jiphyeonjeon, who persistently opposed the creation of Hunminjeongeum. Rather, it is said that Sejong not only opposed to his will as a king, but also temporarily imprisoned him because he could not leave him in the way of creating Jeongum, and then visited him in prison at night to persuade him of his loyalty.

The rumor of Choi Man-ri's appeal against the creation of Jeongum served as an opportunity to encourage Jeongum creation to be more faithful and perfect. King Sejong's once anger suppressed the reign of the nation's greatest holy army.